### PR TITLE
Don't go back to picture flow if wps select option isn't set accordingly

### DIFF
--- a/apps/gui/wps.c
+++ b/apps/gui/wps.c
@@ -1049,28 +1049,33 @@ long gui_wps_show(void)
                 }
                 break;
 
-                /* iPod Classic 6G custom: open PictureFlow instead of stopping */
             case ACTION_WPS_STOP:
                 {
-                    theme_enabled = false;
-                    gwps_leave_wps(false);
-                    filetype_load_plugin("pictureflow", NULL);
-                    if (!(audio_status() & AUDIO_STATUS_PLAY))
+                    int sel_action = global_settings.wps_select_action;
+                    if (sel_action == 2)
                     {
-                        /* audio stopped in PictureFlow; return to WPS
-                           via wpsscrn() which handles playlist resume */
-                        gwps_leave_wps(true);
-                        return GO_TO_WPS;
+                        /* iPod Classic 6G custom: return to PictureFlow instead of stopping 
+                        if sel_action = 2 */
+                        theme_enabled = false;
+                        gwps_leave_wps(false);
+                        filetype_load_plugin("pictureflow", NULL);
+                        if (!(audio_status() & AUDIO_STATUS_PLAY))
+                        {
+                            /* audio stopped in PictureFlow; return to WPS
+                            via wpsscrn() which handles playlist resume */
+                            gwps_leave_wps(true);
+                            return GO_TO_WPS;
+                        }
+                        restore = true;
                     }
-                    restore = true;
+                    else
+                    {
+                        /* In other cases, stop & exit */
+                        bookmark = true;
+                        exit = true;
+                    }
                 }
                 break;
-#if 0 /* original stop behavior */
-            case ACTION_WPS_STOP:
-                bookmark = true;
-                exit = true;
-                break;
-#endif
 
             case ACTION_WPS_LIST_BOOKMARKS:
                 gwps_leave_wps(true);


### PR DESCRIPTION
When maintaining PLAY/PAUSE from WPS, my iPod was going to picture flow rather than shutting down correctly because pictureflow was trying to build its database

Change-Id: Ic0e6b781f84361650789be28fbdb225392676f96