### PR TITLE
Fix 48khz slow playback #14

### DIFF
--- a/apps/iap/iap-core.c
+++ b/apps/iap/iap-core.c
@@ -45,6 +45,7 @@
 #include "usb.h"
 #ifdef USB_ENABLE_AUDIO
 #include "../usbstack/usb_audio.h"
+#include "pcm_mixer.h"
 #endif
 
 #include "tuner.h"
@@ -92,6 +93,10 @@ static bool iap_setupflag = false, iap_running = false;
  */
 static bool iap_shutdown = false;
 static struct timeout iap_task_tmo;
+#ifdef USB_ENABLE_AUDIO
+static unsigned long iap_audio_reported_frequency;
+static unsigned long iap_audio_pending_frequency;
+#endif
 
 unsigned long iap_remotebtn = 0;
 /* Used to make sure a button press is delivered to the processing
@@ -357,6 +362,10 @@ void iap_reset_device(struct device_t* device)
     device->capabilities = 0;
     device->capabilities_queried = 0;
     device->audio_init_pending = false;
+#ifdef USB_ENABLE_AUDIO
+    iap_audio_reported_frequency = 0;
+    iap_audio_pending_frequency = 0;
+#endif
 }
 
 static int iap_task(struct timeout *tmo)
@@ -453,10 +462,33 @@ static void iap_thread(void)
 }
 
 /* called by playback when the next track starts */
-static void iap_track_changed(unsigned short id, void *ignored)
+static void iap_track_changed(unsigned short id, void *param)
 {
     (void)id;
-    (void)ignored;
+
+#ifdef USB_ENABLE_AUDIO
+    struct track_event *te = param;
+    unsigned long frequency = mixer_get_frequency();
+
+    if (global_settings.play_frequency)
+        frequency = global_settings.play_frequency;
+    else if (te && te->id3 && te->id3->frequency)
+        frequency = (te->id3->frequency % 4000) ? SAMPR_44 : SAMPR_48;
+
+    if (DEVICE_LINGO_SUPPORTED(0x0A)
+        && iap_audio_reported_frequency != frequency)
+    {
+        iap_audio_pending_frequency = frequency;
+        if (!device.audio_init_pending)
+        {
+            device.audio_init_pending = true;
+            queue_post(&iap_queue, IAP_EV_TICK, 0);
+        }
+    }
+#else
+    (void)param;
+#endif
+
     if ((interface_state == IST_EXTENDED) && device.do_notify) {
         long playlist_pos = playlist_next(0);
         playlist_pos -= playlist_get_first_index(NULL);
@@ -1379,13 +1411,25 @@ static void iap_handlepkt_mode10(const unsigned int len, const unsigned char *bu
         /* RetAccSampleRateCaps (0x03) — respond with TrackNewAudioAttributes */
         case 0x03:
         {
+#ifdef USB_ENABLE_AUDIO
+            unsigned long frequency;
+#endif
             (void)off;
             IAP_TX_INIT(0x0A, 0x04);
             if (device.auth.idps) {
                 IAP_TX_PUT(tid_hi);
                 IAP_TX_PUT(tid_lo);
             }
+#ifdef USB_ENABLE_AUDIO
+            frequency = iap_audio_pending_frequency ?
+                        iap_audio_pending_frequency : mixer_get_frequency();
+            usb_audio_set_source_sampling_frequency(frequency);
+            IAP_TX_PUT_U32(frequency);  /* sample rate */
+            iap_audio_reported_frequency = frequency;
+            iap_audio_pending_frequency = 0;
+#else
             IAP_TX_PUT_U32(44100);  /* sample rate */
+#endif
             IAP_TX_PUT_U32(0);      /* sound check value */
             IAP_TX_PUT_U32(0);      /* volume adjustment */
             iap_send_tx();

--- a/firmware/usbstack/usb_audio.c
+++ b/firmware/usbstack/usb_audio.c
@@ -447,6 +447,7 @@ static int usb_as_source_intf_alt; /* source streaming interface alternate setti
 
 static int as_playback_freq_idx; /* audio playback streaming frequency index (in hw_freq_sampr) */
 static int as_source_freq_idx; /* audio source streaming frequency index (in hw_freq_sampr) */
+static bool source_freq_set_by_host;
 
 #if USB_NUM_ENDPOINTS <= 3
 /* Source-only: no sink endpoints on limited-EP targets (iPod 5G).
@@ -615,6 +616,8 @@ static const void *source_pull_buf;     /* current buffer from PCM mixer */
 static size_t source_pull_size;         /* total size of current buffer */
 static size_t source_pull_cursor;       /* bytes consumed from current buffer */
 static bool source_pull_mode = false;   /* true when USB ISR drives audio */
+
+static void set_source_sampling_frequency(unsigned long f);
 
 /* DMA inhibit flag defined in pcm-s5l8702.c — prevents I2S DMA restart
  * when the PCM engine internally calls pcm_play_dma_start() during
@@ -980,8 +983,9 @@ static void usb_audio_stop_playback(void)
 /*
  * Compute number of bytes to send in this USB frame.
  * Handles non-integer sample rates (e.g. 44100 Hz / 1000 = 44.1 samples/frame)
- * using a fractional accumulator. Uses the nominal frequency (what the DAC
- * expects via USB descriptor). The write-side throttle in source_buffer_hook()
+ * using a fractional accumulator. Uses the nominal frequency requested by
+ * the host, or the mixer frequency if the host has not requested one.
+ * The write-side throttle in source_buffer_hook()
  * handles the I2S vs USB clock drift.
  */
 static int source_frame_bytes(void)
@@ -1015,8 +1019,23 @@ static void set_source_sampling_frequency(unsigned long f)
             as_source_freq_idx = i;
     }
 
-    logf("usbaudio: set source sampling frequency to %lu Hz for a requested %lu Hz",
-        hw_freq_sampr[as_source_freq_idx], f);
+    source_frac_num = 0;
+
+    if (!source_streaming)
+        logf("usbaudio: set source sampling frequency to %lu Hz for a requested %lu Hz",
+            hw_freq_sampr[as_source_freq_idx], f);
+}
+
+static void usb_audio_sync_source_sampling_frequency(void)
+{
+    if (!source_freq_set_by_host)
+        set_source_sampling_frequency(mixer_get_frequency());
+}
+
+void usb_audio_set_source_sampling_frequency(unsigned long f)
+{
+    source_freq_set_by_host = false;
+    set_source_sampling_frequency(f);
 }
 
 /* Ring buffer hook for legacy (non-pull) source mode.
@@ -1132,6 +1151,8 @@ static void source_fill_buffer(unsigned char *buf, int frame_bytes)
 
 static void usb_audio_start_source(void)
 {
+    usb_audio_sync_source_sampling_frequency();
+
     logf("usbaudio: start source (pull) at %lu Hz ep=0x%02X", hw_freq_sampr[as_source_freq_idx], EP_ISO_SOURCE_IN);
 
     source_streaming = true;
@@ -1371,6 +1392,7 @@ static bool usb_audio_source_endpoint_request(struct usb_ctrlrequest* req, void 
             }
             if (reqdata) {
                 set_source_sampling_frequency(decode3(reqdata));
+                source_freq_set_by_host = true;
                 usb_drv_control_response(USB_CONTROL_ACK, NULL, 0);
                 return true;
             } else {
@@ -1720,11 +1742,13 @@ void usb_audio_init_connection(void)
 
     /* source mode init */
     usb_as_source_intf_alt = 0;
-    as_source_freq_idx = HW_FREQ_44; /* default to 44.1kHz */
+    as_source_freq_idx = HW_FREQ_DEFAULT;
+    source_freq_set_by_host = false;
     source_streaming = false;
     source_frac_num = 0;
     tx_write_pos = 0;
     tx_read_pos = 0;
+    usb_audio_sync_source_sampling_frequency();
 }
 
 void usb_audio_disconnect(void)

--- a/firmware/usbstack/usb_audio.h
+++ b/firmware/usbstack/usb_audio.h
@@ -274,6 +274,8 @@ bool usb_audio_source_streaming(void);
 
 unsigned long usb_audio_get_source_sampling_frequency(void);
 
+void usb_audio_set_source_sampling_frequency(unsigned long f);
+
 int usb_audio_get_source_ring_available(void);
 
 int usb_audio_get_source_underflow_count(void);


### PR DESCRIPTION
I built and tested this on my iPod Classic gen 6.

I tried switching between 44.1 kHz and 48 kHz songs manually, the USB-DAC debug shows the sample rate changing, and the speed of 48 kHz songs is no longer slow. I also put it in shuffle mode on all tracks and rapidly switched between tracks with different sample rates to make sure it worked.

Potential issues: (1) I have not tested with sample rates different from 44.1 kHz and 48 kHz, (2) I am also not checking if the DAC or dock actually supports 48 kHz.

The build is available here: https://github.com/emaadmanzoor/rockpod/releases/tag/mfi-48khz-fix-1