### PR TITLE
Added AA preloading with caching AA buff slots = 5

### DIFF
--- a/apps/SOURCES
+++ b/apps/SOURCES
@@ -166,6 +166,9 @@ audio_path.c
 audio_thread.c
 pcmbuf.c
 codec_thread.c
+#ifdef HAVE_ALBUMART
+albumart_cache.c
+#endif
 playback.c
 codecs.c
 #ifndef HAVE_HARDWARE_BEEP

--- a/apps/albumart_cache.c
+++ b/apps/albumart_cache.c
@@ -1,0 +1,599 @@
+/***************************************************************************
+ *             __________               __   ___.
+ *   Open      \______   \ ____   ____ |  | _\_ |__   _______  ___
+ *   Source     |       _//  _ \_/ ___\|  |/ /| __ \ /  _ \  \/  /
+ *   Jukebox    |    |   (  <_> )  \___|    < | \_\ (  <_> > <  <
+ *   Firmware   |____|_  /\____/ \___  >__|_ \|___  /\____/__/\_ \
+ *                     \/            \/     \/    \/            \/
+ *
+ * Copyright (C) 2026 Rockbox contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ****************************************************************************/
+
+#include "config.h"
+
+#ifdef HAVE_ALBUMART
+
+#include <string.h>
+#include "albumart_cache.h"
+#include "albumart.h"
+#include "file.h"
+#include "kernel.h"
+#include "logf.h"
+#include "pathfuncs.h"
+#include "settings.h"
+#include "string-extra.h"
+#include "system.h"
+
+#define AA_MAX_DIM_SLOTS 4
+
+enum aa_src
+{
+    AA_SRC_NONE = 0,
+    AA_SRC_FILE,
+    AA_SRC_EMBEDDED,
+};
+
+struct aa_ident
+{
+    enum aa_src src;
+    int dim_slot;
+    off_t emb_pos;
+    int emb_size;
+    char path[MAX_PATH];
+};
+
+struct aa_block
+{
+    struct aa_ident ident;
+    struct bitmap *bmp;
+    bool in_use;
+};
+
+static struct mutex aa_mutex;
+
+static void *scratch;
+static size_t scratch_size;
+
+static struct dim slot_dim[AA_MAX_DIM_SLOTS];
+static size_t slot_block_size[AA_MAX_DIM_SLOTS];
+static int nslots;
+
+static struct aa_block blocks[AA_MAX_DIM_SLOTS][AA_WINDOW_SIZE];
+/* Published window: playlist offset -2..+2 -> block index or -1 */
+static int window[AA_WINDOW_SIZE][AA_MAX_DIM_SLOTS];
+static unsigned int work_gen;
+
+static int win_index(int pl_offset)
+{
+    return pl_offset + AA_WINDOW_RADIUS;
+}
+
+static bool ident_equal(const struct aa_ident *a, const struct aa_ident *b)
+{
+    if (a->src != b->src || a->dim_slot != b->dim_slot ||
+        a->src == AA_SRC_NONE)
+        return false;
+
+    if (a->src == AA_SRC_EMBEDDED &&
+        (a->emb_pos != b->emb_pos || a->emb_size != b->emb_size))
+        return false;
+
+    return strcmp(a->path, b->path) == 0;
+}
+
+static void ident_clear(struct aa_ident *id)
+{
+    memset(id, 0, sizeof(*id));
+}
+
+static bool resolve_ident(const struct mp3entry *id3, int dim_slot,
+                          struct aa_ident *out)
+{
+    ident_clear(out);
+    out->dim_slot = dim_slot;
+
+    if (!id3 || global_settings.album_art == AA_OFF)
+        return false;
+
+    char path[MAX_PATH];
+    bool checked_image_file = false;
+
+    if (global_settings.album_art == AA_PREFER_IMAGE_FILE)
+    {
+        if (find_albumart(id3, path, sizeof(path), &slot_dim[dim_slot]))
+        {
+            out->src = AA_SRC_FILE;
+            strmemccpy(out->path, path, sizeof(out->path));
+            return true;
+        }
+        checked_image_file = true;
+    }
+
+    if (id3->has_embedded_albumart &&
+        (id3->albumart.type & AA_CLEAR_FLAGS_MASK) == AA_TYPE_JPG)
+    {
+        out->src = AA_SRC_EMBEDDED;
+        out->emb_pos = id3->albumart.pos;
+        out->emb_size = id3->albumart.size;
+        strmemccpy(out->path, id3->path, sizeof(out->path));
+        return true;
+    }
+
+    if (!checked_image_file &&
+        find_albumart(id3, path, sizeof(path), &slot_dim[dim_slot]))
+    {
+        out->src = AA_SRC_FILE;
+        strmemccpy(out->path, path, sizeof(out->path));
+        return true;
+    }
+
+    return false;
+}
+
+static int find_block_by_ident(const struct aa_ident *id)
+{
+    int d = id->dim_slot;
+    int b;
+
+    for (b = 0; b < AA_WINDOW_SIZE; b++)
+    {
+        if (blocks[d][b].ident.src != AA_SRC_NONE &&
+            ident_equal(&blocks[d][b].ident, id))
+            return b;
+    }
+    return -1;
+}
+
+static bool block_in_window(int dim_slot, int b, int win[][AA_MAX_DIM_SLOTS])
+{
+    int i;
+    for (i = 0; i < AA_WINDOW_SIZE; i++)
+    {
+        if (win[i][dim_slot] == b)
+            return true;
+    }
+    return false;
+}
+
+static int find_free_block(int dim_slot, int wi)
+{
+    int b;
+
+    for (b = 0; b < AA_WINDOW_SIZE; b++)
+    {
+        if (!block_in_window(dim_slot, b, window))
+            return b;
+    }
+
+    /* Overwrite this offset's existing block if the window is full */
+    if (wi >= 0 && wi < AA_WINDOW_SIZE && window[wi][dim_slot] >= 0)
+        return window[wi][dim_slot];
+
+    return -1;
+}
+
+static void recompute_in_use(void)
+{
+    int d, b, i;
+
+    for (d = 0; d < nslots; d++)
+    {
+        for (b = 0; b < AA_WINDOW_SIZE; b++)
+            blocks[d][b].in_use = false;
+
+        for (i = 0; i < AA_WINDOW_SIZE; i++)
+        {
+            b = window[i][d];
+            if (b >= 0)
+            {
+                blocks[d][b].in_use = true;
+            }
+        }
+    }
+}
+
+static void windows_reset(int win[][AA_MAX_DIM_SLOTS])
+{
+    int i, d;
+    for (i = 0; i < AA_WINDOW_SIZE; i++)
+        for (d = 0; d < AA_MAX_DIM_SLOTS; d++)
+            win[i][d] = -1;
+}
+
+static int decode_ident_to_scratch(const struct aa_ident *id)
+{
+    int d = id->dim_slot;
+    size_t max_size = scratch_size;
+    int fd;
+    int rc;
+    struct mp3_albumart embedded;
+    struct mp3_albumart *emb = NULL;
+    const char *path = id->path;
+
+    if (!scratch || max_size == 0 || slot_block_size[d] == 0)
+        return 0;
+
+    if (id->src == AA_SRC_EMBEDDED)
+    {
+        embedded.pos = id->emb_pos;
+        embedded.size = id->emb_size;
+        embedded.type = AA_TYPE_JPG;
+        emb = &embedded;
+    }
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return 0;
+
+    rc = albumart_decode_fd(fd, path, &slot_dim[d], emb, scratch, max_size);
+    close(fd);
+
+    if (rc <= (int)sizeof(struct bitmap))
+        return 0;
+
+    if ((size_t)rc > slot_block_size[d])
+        rc = slot_block_size[d];
+
+    return rc;
+}
+
+static void install_scratch_into_block(const struct aa_ident *id, int b,
+                                       int rc)
+{
+    int d = id->dim_slot;
+
+    memcpy(blocks[d][b].bmp, scratch, rc);
+    blocks[d][b].bmp->data =
+        (unsigned char *)blocks[d][b].bmp + sizeof(struct bitmap);
+    blocks[d][b].ident = *id;
+    logf("AA cache load dim=%d blk=%d %s", d, b, id->path);
+}
+
+size_t albumart_cache_pool_size(const struct dim *dims, int n)
+{
+    size_t total = 0;
+    size_t max_scratch = 0;
+    int i;
+
+    if (!dims || n <= 0)
+        return 0;
+
+    if (n > AA_MAX_DIM_SLOTS)
+        n = AA_MAX_DIM_SLOTS;
+
+    for (i = 0; i < n; i++)
+    {
+        size_t decoded;
+        size_t scratch_need;
+
+        if (dims[i].width <= 0 || dims[i].height <= 0)
+            continue;
+
+        decoded = albumart_decoded_size(&dims[i]);
+        decoded = ALIGN_UP(decoded, sizeof(intptr_t));
+        total += decoded * AA_WINDOW_SIZE;
+
+        scratch_need = decoded + albumart_decode_overhead(dims[i].width);
+        scratch_need = ALIGN_UP(scratch_need, sizeof(intptr_t));
+        if (scratch_need > max_scratch)
+            max_scratch = scratch_need;
+    }
+
+    if (total == 0)
+        return 0;
+
+    return total + max_scratch;
+}
+
+void albumart_cache_reset(void *buf, size_t size,
+                          const struct dim *dims, int n)
+{
+    unsigned char *p;
+    int d, b;
+    static bool mutex_ready = false;
+
+    if (!mutex_ready)
+    {
+        mutex_init(&aa_mutex);
+        mutex_ready = true;
+    }
+
+    mutex_lock(&aa_mutex);
+
+    scratch = NULL;
+    scratch_size = 0;
+    nslots = 0;
+    memset(slot_dim, 0, sizeof(slot_dim));
+    memset(slot_block_size, 0, sizeof(slot_block_size));
+    memset(blocks, 0, sizeof(blocks));
+    windows_reset(window);
+    work_gen++;
+
+    if (!buf || size == 0 || !dims || n <= 0)
+        goto reset_done;
+
+    if (n > AA_MAX_DIM_SLOTS)
+        n = AA_MAX_DIM_SLOTS;
+
+    nslots = n;
+    p = buf;
+
+    /* Scratch first so decode workspace is independent of slots */
+    {
+        size_t max_scratch = 0;
+        for (d = 0; d < n; d++)
+        {
+            size_t need;
+            if (dims[d].width <= 0 || dims[d].height <= 0)
+                continue;
+            need = albumart_decoded_size(&dims[d]) +
+                   albumart_decode_overhead(dims[d].width);
+            need = ALIGN_UP(need, sizeof(intptr_t));
+            if (need > max_scratch)
+                max_scratch = need;
+        }
+
+        if (max_scratch > size)
+            goto reset_done;
+
+        scratch = p;
+        scratch_size = max_scratch;
+        p += max_scratch;
+        size -= max_scratch;
+    }
+
+    for (d = 0; d < n; d++)
+    {
+        size_t decoded;
+
+        slot_dim[d] = dims[d];
+        if (dims[d].width <= 0 || dims[d].height <= 0)
+            continue;
+
+        decoded = ALIGN_UP(albumart_decoded_size(&dims[d]), sizeof(intptr_t));
+        if (decoded * AA_WINDOW_SIZE > size)
+            break;
+
+        slot_block_size[d] = decoded;
+        for (b = 0; b < AA_WINDOW_SIZE; b++)
+        {
+            blocks[d][b].bmp = (struct bitmap *)p;
+            ident_clear(&blocks[d][b].ident);
+            blocks[d][b].in_use = false;
+            p += decoded;
+            size -= decoded;
+        }
+    }
+
+reset_done:
+    mutex_unlock(&aa_mutex);
+}
+
+void albumart_cache_clear(void)
+{
+    int d, b;
+
+    mutex_lock(&aa_mutex);
+    windows_reset(window);
+    work_gen++;
+    for (d = 0; d < AA_MAX_DIM_SLOTS; d++)
+    {
+        for (b = 0; b < AA_WINDOW_SIZE; b++)
+        {
+            ident_clear(&blocks[d][b].ident);
+            blocks[d][b].in_use = false;
+        }
+    }
+    mutex_unlock(&aa_mutex);
+}
+
+void albumart_cache_kick(void)
+{
+    mutex_lock(&aa_mutex);
+    work_gen++;
+    mutex_unlock(&aa_mutex);
+}
+
+bool albumart_cache_work(int pl_offset, const struct mp3entry *id3)
+{
+    int wi = win_index(pl_offset);
+    int d;
+    unsigned int gen;
+    bool current;
+
+    if (wi < 0 || wi >= AA_WINDOW_SIZE)
+        return false;
+
+    current = (pl_offset == 0);
+
+    mutex_lock(&aa_mutex);
+    gen = work_gen;
+    mutex_unlock(&aa_mutex);
+
+    for (d = 0; d < nslots; d++)
+    {
+        struct aa_ident id;
+        int b;
+        int rc;
+
+        if (slot_block_size[d] == 0)
+            continue;
+
+        if (!id3 || !resolve_ident(id3, d, &id))
+        {
+            mutex_lock(&aa_mutex);
+            if (gen != work_gen)
+            {
+                mutex_unlock(&aa_mutex);
+                return false;
+            }
+            window[wi][d] = -1;
+            recompute_in_use();
+            mutex_unlock(&aa_mutex);
+            continue;
+        }
+
+        mutex_lock(&aa_mutex);
+        if (gen != work_gen)
+        {
+            mutex_unlock(&aa_mutex);
+            return false;
+        }
+
+        b = find_block_by_ident(&id);
+        if (b >= 0)
+        {
+            window[wi][d] = b;
+            recompute_in_use();
+            mutex_unlock(&aa_mutex);
+            continue;
+        }
+        mutex_unlock(&aa_mutex);
+
+        rc = decode_ident_to_scratch(&id);
+        if (rc <= 0)
+            continue;
+
+        mutex_lock(&aa_mutex);
+        if (gen != work_gen)
+        {
+            mutex_unlock(&aa_mutex);
+            return false;
+        }
+
+        b = find_block_by_ident(&id);
+        if (b < 0)
+            b = find_free_block(d, wi);
+        if (b < 0)
+        {
+            mutex_unlock(&aa_mutex);
+            continue;
+        }
+
+        install_scratch_into_block(&id, b, rc);
+        window[wi][d] = b;
+        recompute_in_use();
+        mutex_unlock(&aa_mutex);
+    }
+
+    mutex_lock(&aa_mutex);
+    if (gen != work_gen)
+        current = false;
+    mutex_unlock(&aa_mutex);
+    return current;
+}
+
+void albumart_cache_lock(void)
+{
+    mutex_lock(&aa_mutex);
+}
+
+void albumart_cache_unlock(void)
+{
+    mutex_unlock(&aa_mutex);
+}
+
+void albumart_cache_slide_locked(int delta)
+{
+    int d, i;
+    int tmp[AA_WINDOW_SIZE];
+
+    if (delta == 0)
+        return;
+
+    work_gen++;
+
+    for (d = 0; d < nslots; d++)
+    {
+        for (i = 0; i < AA_WINDOW_SIZE; i++)
+        {
+            int src = i + delta;
+            if (src >= 0 && src < AA_WINDOW_SIZE)
+                tmp[i] = window[src][d];
+            else
+                tmp[i] = -1;
+        }
+        for (i = 0; i < AA_WINDOW_SIZE; i++)
+            window[i][d] = tmp[i];
+    }
+    recompute_in_use();
+}
+
+struct bitmap *albumart_cache_get_locked(int pl_offset, int dim_slot)
+{
+    int wi = win_index(pl_offset);
+    int b;
+
+    if (wi < 0 || wi >= AA_WINDOW_SIZE ||
+        (unsigned)dim_slot >= (unsigned)nslots)
+        return NULL;
+
+    b = window[wi][dim_slot];
+    if (b >= 0 && blocks[dim_slot][b].in_use)
+        return blocks[dim_slot][b].bmp;
+    return NULL;
+}
+
+struct bitmap *albumart_cache_get(int pl_offset, int dim_slot)
+{
+    struct bitmap *bmp;
+    mutex_lock(&aa_mutex);
+    bmp = albumart_cache_get_locked(pl_offset, dim_slot);
+    mutex_unlock(&aa_mutex);
+    return bmp;
+}
+
+void albumart_cache_get_debugdata(struct albumart_cache_debug *dbg)
+{
+    int d, b, i;
+
+    if (!dbg)
+        return;
+
+    memset(dbg, 0, sizeof(*dbg));
+
+    mutex_lock(&aa_mutex);
+    for (d = 0; d < nslots; d++)
+    {
+        if (slot_block_size[d] == 0)
+            continue;
+
+        dbg->slots_total += AA_WINDOW_SIZE;
+        dbg->pool_size += slot_block_size[d] * AA_WINDOW_SIZE;
+
+        for (b = 0; b < AA_WINDOW_SIZE; b++)
+        {
+            if (blocks[d][b].in_use)
+            {
+                dbg->slots_used++;
+                dbg->used_size += slot_block_size[d];
+            }
+        }
+    }
+
+    for (i = 0; i < AA_WINDOW_SIZE; i++)
+    {
+        dbg->occupied[i] = 0;
+        for (d = 0; d < nslots; d++)
+        {
+            b = window[i][d];
+            if (b >= 0 && blocks[d][b].in_use)
+            {
+                dbg->occupied[i] = 1;
+                break;
+            }
+        }
+    }
+    mutex_unlock(&aa_mutex);
+}
+
+#endif /* HAVE_ALBUMART */

--- a/apps/albumart_cache.h
+++ b/apps/albumart_cache.h
@@ -1,0 +1,82 @@
+/***************************************************************************
+ *             __________               __   ___.
+ *   Open      \______   \ ____   ____ |  | _\_ |__   _______  ___
+ *   Source     |       _//  _ \_/ ___\|  |/ /| __ \ /  _ \  \/  /
+ *   Jukebox    |    |   (  <_> )  \___|    < | \_\ (  <_> > <  <
+ *   Firmware   |____|_  /\____/ \___  >__|_ \|___  /\____/__/\_ \
+ *                     \/            \/     \/    \/            \/
+ *
+ * Copyright (C) 2026 Rockbox contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ****************************************************************************/
+
+#ifndef _ALBUMART_CACHE_H_
+#define _ALBUMART_CACHE_H_
+
+#include "config.h"
+
+#ifdef HAVE_ALBUMART
+
+#include <stddef.h>
+#include <stdbool.h>
+#include "bmp.h"
+#include "metadata.h"
+
+#define AA_WINDOW_RADIUS 2
+#define AA_WINDOW_SIZE   (2 * AA_WINDOW_RADIUS + 1)
+
+struct dim;
+
+/* Bytes to carve from the audio buffer for the given claimed AA dims.
+ * dims[i] is unused when width or height is 0. */
+size_t albumart_cache_pool_size(const struct dim *dims, int nslots);
+
+/* Bind the cache to a freshly carved pool. Clears all loaded images. */
+void albumart_cache_reset(void *buf, size_t size,
+                          const struct dim *dims, int nslots);
+
+/* Drop decoded images but keep the pool (playback stop). */
+void albumart_cache_clear(void);
+
+/* Invalidate in-flight decode and start a new window fill. */
+void albumart_cache_kick(void);
+
+/* Decode and publish one playlist-relative offset (all claimed dims).
+ * id3 may be NULL when metadata is unavailable. Returns true if this
+ * completed offset 0 for the current generation. */
+bool albumart_cache_work(int pl_offset, const struct mp3entry *id3);
+
+/* Bitmap for playlist-relative offset and claimed dim slot, or NULL. */
+struct bitmap *albumart_cache_get(int pl_offset, int dim_slot);
+
+/* Serialize skip_offset vs window: lock, slide, unlock. */
+void albumart_cache_lock(void);
+void albumart_cache_unlock(void);
+void albumart_cache_slide_locked(int delta);
+struct bitmap *albumart_cache_get_locked(int pl_offset, int dim_slot);
+
+struct albumart_cache_debug {
+    size_t pool_size;   /* decoded-image capacity, excluding decode scratch */
+    size_t used_size;   /* bytes in occupied slots */
+    int slots_used;
+    int slots_total;
+    /* occupied[i] is playlist offset i - AA_WINDOW_RADIUS */
+    char occupied[AA_WINDOW_SIZE];
+    int work_index;     /* 0..AA_WINDOW_SIZE; SIZE means idle */
+    int work_offset;    /* next/current playlist-relative load offset */
+    int skip_offset;    /* WPS preview offset; 0 if none */
+};
+
+void albumart_cache_get_debugdata(struct albumart_cache_debug *dbg);
+
+#endif /* HAVE_ALBUMART */
+
+#endif /* _ALBUMART_CACHE_H_ */

--- a/apps/audio_thread.h
+++ b/apps/audio_thread.h
@@ -47,6 +47,7 @@ enum
 
     /* audio -> audio */
     Q_AUDIO_FILL_BUFFER,        /* continue buffering next track */
+    Q_AUDIO_AA_WORK,            /* decode one album-art window slot */
 
     /* buffering -> audio */
     Q_AUDIO_BUFFERING,          /* some buffer event */

--- a/apps/buffering.c
+++ b/apps/buffering.c
@@ -32,7 +32,6 @@
 #include "bmp.h"
 #ifdef HAVE_ALBUMART
 #include "albumart.h"
-#include "jpeg_load.h"
 #include "playback.h"
 #endif
 #include "buffering.h"
@@ -848,34 +847,8 @@ static int load_image(int fd, const char *path,
                       struct bufopen_bitmap_data *data,
                       size_t bufidx, size_t max_size)
 {
-    (void)path;
-    int rc;
-    struct bitmap *bmp = ringbuf_ptr(bufidx);
-    struct dim *dim = data->dim;
-    struct mp3_albumart *aa = data->embedded_albumart;
-
-    /* get the desired image size */
-    bmp->width = dim->width, bmp->height = dim->height;
-    /* FIXME: alignment may be needed for the data buffer. */
-    bmp->data = ringbuf_ptr(bufidx + sizeof(struct bitmap));
-
-#if (LCD_DEPTH > 1) || defined(HAVE_REMOTE_LCD) && (LCD_REMOTE_DEPTH > 1)
-    bmp->maskdata = NULL;
-#endif
-    const int format = FORMAT_NATIVE | FORMAT_DITHER |
-                       FORMAT_RESIZE | FORMAT_KEEP_ASPECT;
-#ifdef HAVE_JPEG
-    if (aa != NULL) {
-        lseek(fd, aa->pos, SEEK_SET);
-        rc = clip_jpeg_fd(fd, aa->type, aa->size, bmp, (int)max_size, format, NULL);
-    }
-    else if (strcmp(path + strlen(path) - 4, ".bmp"))
-        rc = read_jpeg_fd(fd, bmp, (int)max_size, format, NULL);
-    else
-#endif
-        rc = read_bmp_fd(fd, bmp, (int)max_size, format, NULL);
-
-    return rc + (rc > 0 ? sizeof(struct bitmap) : 0);
+    return albumart_decode_fd(fd, path, data->dim, data->embedded_albumart,
+                              ringbuf_ptr(bufidx), max_size);
 }
 #endif /* HAVE_ALBUMART */
 
@@ -965,20 +938,8 @@ int bufopen(const char *file, off_t offset, enum data_type type,
          * so the file size should not be used as it may be too large
          * or too small */
         struct bufopen_bitmap_data *aa = user_data;
-        size = BM_SIZE(aa->dim->width, aa->dim->height, FORMAT_NATIVE, false);
-        size += sizeof(struct bitmap);
-
-#ifdef HAVE_JPEG
-        /* JPEG loading requires extra memory
-         * TODO: don't add unncessary overhead for .bmp images! */
-        size += JPEG_DECODE_OVERHEAD;
-#endif
-       /* resize_on_load requires space for 1 line + 2 spare lines */
-#ifdef HAVE_LCD_COLOR
-        size += sizeof(struct uint32_argb) * 3 * aa->dim->width;
-#else
-        size += sizeof(uint32_t) * 3 * aa->dim->width;
-#endif
+        size = albumart_decoded_size(aa->dim);
+        size += albumart_decode_overhead(aa->dim->width);
     }
 #endif /* HAVE_ALBUMART */
 

--- a/apps/debug_menu.c
+++ b/apps/debug_menu.c
@@ -86,6 +86,9 @@
 #include "pcmbuf.h"
 #include "buffering.h"
 #include "playback.h"
+#ifdef HAVE_ALBUMART
+#include "albumart_cache.h"
+#endif
 #if defined(HAVE_SPDIF_OUT) || defined(HAVE_SPDIF_IN)
 #include "spdif.h"
 #endif
@@ -478,6 +481,46 @@ static bool dbg_buffering_thread(void)
             screens[i].putsf(0, line++, "track count: %2u", audio_track_count());
 
             screens[i].putsf(0, line++, "handle count: %d", (int)d.num_handles);
+
+#ifdef HAVE_ALBUMART
+            {
+                struct albumart_cache_debug aa;
+                playback_aa_get_debugdata(&aa);
+
+                screens[i].putsf(0, line++, fmt_used, "aa",
+                                 (long)aa.used_size, (long)aa.pool_size);
+
+                gui_scrollbar_draw(&screens[i], 0, line*SYSFONT_HEIGHT,
+                                   screens[i].lcdwidth, 6,
+                                   aa.pool_size ? (int)aa.pool_size : 1,
+                                   0, (int)aa.used_size, HORIZONTAL);
+                line++;
+
+                screens[i].putsf(0, line++, "aa slots: %d/%d",
+                                 aa.slots_used, aa.slots_total);
+
+                screens[i].putsf(0, line++,
+                    "aa win: -2 %c -1 %c 0 %c +1 %c +2 %c",
+                    aa.occupied[0] ? '#' : '.',
+                    aa.occupied[1] ? '#' : '.',
+                    aa.occupied[2] ? '#' : '.',
+                    aa.occupied[3] ? '#' : '.',
+                    aa.occupied[4] ? '#' : '.');
+
+                if (aa.skip_offset)
+                    screens[i].putsf(0, line++,
+                                     "aa job: %d/%d off=%d skip=%d",
+                                     aa.work_index, AA_WINDOW_SIZE,
+                                     aa.work_offset, aa.skip_offset);
+                else
+                    screens[i].putsf(0, line++, "aa job: %d/%d off=%d",
+                                     aa.work_index, AA_WINDOW_SIZE,
+                                     aa.work_offset);
+
+                screens[i].putsf(0, line++, "aa now: %s",
+                                 aa.occupied[AA_WINDOW_RADIUS] ? "yes" : "no");
+            }
+#endif
 
 #if (CONFIG_PLATFORM & PLATFORM_NATIVE)
             screens[i].putsf(0, line++, "cpu freq: %3dMHz",

--- a/apps/gui/skin_engine/skin_albumart_color.c
+++ b/apps/gui/skin_engine/skin_albumart_color.c
@@ -28,7 +28,6 @@
 #include "kernel.h"
 #include "audio.h"
 #include "playback.h"
-#include "buffering.h"
 #include "appevents.h"
 #include "skin_albumart_color.h"
 
@@ -448,12 +447,10 @@ void dynamic_colors_check_extraction(int aa_slot)
         return;
     }
 
-    int handle = playback_current_aa_hid(aa_slot);
-    if (handle >= 0)
+    struct bitmap *bmp = playback_current_aa_bitmap(aa_slot);
+    if (bmp)
     {
-        struct bitmap *bmp;
-        if (bufgetdata(handle, 0, (void *)&bmp) > 0)
-            extract_colors(bmp);
+        extract_colors(bmp);
         needs_extraction = false;
     }
     else

--- a/apps/gui/skin_engine/skin_display.c
+++ b/apps/gui/skin_engine/skin_display.c
@@ -424,10 +424,10 @@ void wps_display_images(struct gui_wps *gwps, struct viewport* vp)
 #ifdef HAVE_ALBUMART
     /* now draw the AA */
     struct skin_albumart *aa = SKINOFFSETTOPTR(get_skin_buffer(data), data->albumart);
-    if (aa && aa->draw_handle >= 0)
+    if (aa && aa->draw_bmp)
     {
-        draw_album_art(gwps, aa->draw_handle, false);
-        aa->draw_handle = -1;
+        draw_album_art(gwps, aa->draw_bmp, false);
+        aa->draw_bmp = NULL;
     }
 #endif
 
@@ -649,21 +649,44 @@ void draw_peakmeters(struct gui_wps *gwps, int line_number,
 }
 
 #ifdef HAVE_ALBUMART
-/* Draw the album art bitmap from the given handle ID onto the given WPS.
-   Call with clear = true to clear the bitmap instead of drawing it. */
-void draw_album_art(struct gui_wps *gwps, int handle_id, bool clear)
+struct bitmap *skin_get_albumart_bitmap(struct wps_data *data)
 {
-    if (!gwps || !gwps->data || !gwps->display || handle_id < 0)
+    struct bitmap *bmp;
+
+    if (!data)
+        return NULL;
+
+    bmp = playback_current_aa_bitmap(data->playback_aa_slot);
+#if CONFIG_TUNER
+    if (in_radio_screen() || (get_radio_status() != FMRADIO_OFF))
+    {
+        struct skin_albumart *aa = SKINOFFSETTOPTR(get_skin_buffer(data),
+                                                   data->albumart);
+        int handle = -1;
+        if (aa)
+        {
+            struct dim dim = { aa->width, aa->height };
+            handle = radio_get_art_hid(&dim);
+        }
+        bmp = NULL;
+        if (handle >= 0)
+            bufgetdata(handle, 0, (void *)&bmp);
+    }
+#endif
+    return bmp;
+}
+
+/* Draw the album art bitmap onto the given WPS.
+   Call with clear = true to clear the bitmap instead of drawing it. */
+void draw_album_art(struct gui_wps *gwps, struct bitmap *bmp, bool clear)
+{
+    if (!gwps || !gwps->data || !gwps->display || !bmp)
         return;
 
     struct wps_data *data = gwps->data;
     struct skin_albumart *aa = SKINOFFSETTOPTR(get_skin_buffer(data), data->albumart);
 
     if (!aa)
-        return;
-
-    struct bitmap *bmp;
-    if (bufgetdata(handle_id, 0, (void *)&bmp) <= 0)
         return;
 
     short x = aa->x;

--- a/apps/gui/skin_engine/skin_display.h
+++ b/apps/gui/skin_engine/skin_display.h
@@ -56,9 +56,10 @@ void write_line(struct screen *display, struct align_pos *format_align,
 void draw_peakmeters(struct gui_wps *gwps, int line_number,
                      struct viewport *viewport);
 #ifdef HAVE_ALBUMART
-/* Draw the album art bitmap from the given handle ID onto the given Skin.
+/* Draw the album art bitmap onto the given Skin.
    Call with clear = true to clear the bitmap instead of drawing it. */
-void draw_album_art(struct gui_wps *gwps, int handle_id, bool clear);
+void draw_album_art(struct gui_wps *gwps, struct bitmap *bmp, bool clear);
+struct bitmap *skin_get_albumart_bitmap(struct wps_data *data);
 #endif
 
 #endif

--- a/apps/gui/skin_engine/skin_parser.c
+++ b/apps/gui/skin_engine/skin_parser.c
@@ -1450,7 +1450,7 @@ static int parse_albumart_load(struct skin_element* element,
     aa->y =  percent_parse_param(get_param(element, 1), curr_vp->vp.height);
     aa->width =  percent_parse_param(get_param(element, 2), curr_vp->vp.width);
     aa->height =  percent_parse_param(get_param(element, 3), curr_vp->vp.height);
-    aa->draw_handle = -1;
+    aa->draw_bmp = NULL;
 
     /* if we got here, we parsed everything ok .. ! */
     if (aa->width < 0)

--- a/apps/gui/skin_engine/skin_render.c
+++ b/apps/gui/skin_engine/skin_render.c
@@ -303,17 +303,7 @@ static bool do_non_text_tags(struct gui_wps *gwps, struct skin_draw_info *info,
             {
                 struct skin_albumart *aa = SKINOFFSETTOPTR(skin_buffer, data->albumart);
                 if (aa)
-                {    
-                    int handle = playback_current_aa_hid(data->playback_aa_slot);
-#if CONFIG_TUNER
-                    if (in_radio_screen() || (get_radio_status() != FMRADIO_OFF))
-                    {
-                        struct dim dim = {aa->width, aa->height};
-                        handle = radio_get_art_hid(&dim);
-                    }
-#endif
-                    aa->draw_handle = handle;
-                }
+                    aa->draw_bmp = skin_get_albumart_bitmap(data);
             }
             break;
         }
@@ -472,8 +462,7 @@ static void do_tags_in_hidden_conditional(struct skin_element* branch,
 #ifdef HAVE_ALBUMART
             else if (token->type == SKIN_TOKEN_ALBUMART_DISPLAY && data->albumart)
             {
-                draw_album_art(gwps,
-                        playback_current_aa_hid(data->playback_aa_slot), true);
+                draw_album_art(gwps, skin_get_albumart_bitmap(data), true);
             }
 #endif
         skip:

--- a/apps/gui/skin_engine/skin_tokens.c
+++ b/apps/gui/skin_engine/skin_tokens.c
@@ -52,6 +52,7 @@
 
 #include "wps_internals.h"
 #include "skin_engine.h"
+#include "skin_display.h"
 #include "statusbar-skinned.h"
 #include "root_menu.h"
 #ifdef HAVE_RECORDING
@@ -1225,18 +1226,7 @@ const char *get_token_value(struct gui_wps *gwps,
         case SKIN_TOKEN_ALBUMART_FOUND:
             if (SKINOFFSETTOPTR(get_skin_buffer(data), data->albumart))
             {
-                int handle = -1;
-                handle = playback_current_aa_hid(data->playback_aa_slot);
-#if CONFIG_TUNER
-                if (in_radio_screen() || (get_radio_status() != FMRADIO_OFF))
-                {
-                    struct skin_albumart *aa = SKINOFFSETTOPTR(get_skin_buffer(data), data->albumart);
-                    if (!aa) return NULL;
-                    struct dim dim = {aa->width, aa->height};
-                    handle = radio_get_art_hid(&dim);
-                }
-#endif
-                if (handle >= 0)
+                if (skin_get_albumart_bitmap(data))
                     return "C";
             }
             return NULL;

--- a/apps/gui/skin_engine/wps_internals.h
+++ b/apps/gui/skin_engine/wps_internals.h
@@ -285,7 +285,7 @@ struct skin_albumart {
     unsigned char yalign; /* WPS_ALBUMART_ALIGN_TOP, _CENTER, _BOTTOM */
     unsigned char state; /* WPS_ALBUMART_NONE, _CHECK, _LOAD */
 
-    int draw_handle;
+    struct bitmap *draw_bmp;
 };
 #endif
 

--- a/apps/playback.c
+++ b/apps/playback.c
@@ -45,6 +45,7 @@
 #include "storage.h"
 #include "misc.h"
 #include "settings.h"
+#include "file.h"
 #include "audiohw.h"
 #include "general.h"
 #include <stdio.h>
@@ -55,6 +56,7 @@
 
 #ifdef HAVE_ALBUMART
 #include "albumart.h"
+#include "albumart_cache.h"
 #endif
 
 #ifdef HAVE_PLAY_FREQ
@@ -187,9 +189,6 @@ static struct albumart_slot
     struct dim dim;     /* Holds width, height of the albumart */
     int used;           /* Counter; increments if something uses it */
 } albumart_slots[MAX_MULTIPLE_AA]; /* (A,O) */
-
-static char last_folder_aa_path[MAX_PATH] = "\0";
-static int last_folder_aa_hid[MAX_MULTIPLE_AA] = {0};
 
 #define FOREACH_ALBUMART(i) for (int i = 0; i < MAX_MULTIPLE_AA; i++)
 #endif /* HAVE_ALBUMART */
@@ -627,20 +626,6 @@ static bool track_list_commit_buf_info(struct track_buf_info *tbip,
     return true;
 }
 
-#ifdef HAVE_ALBUMART
-static inline void clear_cached_aa_handles(int* aa_handles)
-{
-    if (last_folder_aa_path[0] == 0)
-        return;
-
-    FOREACH_ALBUMART(i)
-    {
-        if (aa_handles[i] == last_folder_aa_hid[i])
-            aa_handles[i] = 0;
-    }
-}
-#endif //HAVE_ALBUMART
-
 /* Free the track buffer entry and possibly remove it from the list if it
    was succesfully added at some point */
 static void track_list_free_buf_info(struct track_buf_info *tbip)
@@ -682,9 +667,6 @@ static void track_list_free_buf_info(struct track_buf_info *tbip)
     /* No movement allowed during bufclose calls */
     buf_pin_handle(hid, true);
 
-#ifdef HAVE_ALBUMART
-    clear_cached_aa_handles(tbip->info.aa_hid);
-#endif
     FOR_EACH_TRACK_INFO_HANDLE(i)
         bufclose(tbip->info.handle[i]);
 
@@ -872,20 +854,109 @@ size_t audio_buffer_available(void)
     return MAX(core_size, size);
 }
 
-#ifdef HAVE_ALBUMART
-static void clear_last_folder_album_art(void)
-{
-    if(last_folder_aa_path[0] == 0)
-        return;
+static void send_track_event(unsigned int id, unsigned int flags,
+                             struct mp3entry *id3);
 
-    last_folder_aa_path[0] = 0;
+#ifdef HAVE_ALBUMART
+static int aa_work_index;
+static unsigned int aa_job_gen;
+static const int aa_work_order[AA_WINDOW_SIZE] = { 0, -1, 1, -2, 2 };
+
+static void playback_aa_claimed_dims(struct dim *dims)
+{
     FOREACH_ALBUMART(i)
     {
-        bufclose(last_folder_aa_hid[i]);
-        last_folder_aa_hid[i] = 0;
+        if (albumart_slots[i].used)
+            dims[i] = albumart_slots[i].dim;
+        else
+        {
+            dims[i].width = 0;
+            dims[i].height = 0;
+        }
     }
 }
-#endif
+
+static bool playback_aa_fill_id3(int pl_offset, struct mp3entry *id3)
+{
+    struct track_info info;
+    char path[MAX_PATH + 1];
+    int fd;
+    bool ok;
+
+    if (track_list_user_current(pl_offset, &info) &&
+        bufreadid3(info.id3_hid, id3))
+        return true;
+
+    if (!playlist_peek(pl_offset, path, sizeof(path)))
+        return false;
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return false;
+
+    ok = get_metadata(id3, fd, path);
+    close(fd);
+    return ok;
+}
+
+static void playback_aa_kick(void)
+{
+    if (play_status == PLAY_STOPPED)
+        return;
+
+    albumart_cache_kick();
+    aa_job_gen++;
+    aa_work_index = 0;
+    LOGFQUEUE("audio > audio Q_AUDIO_AA_WORK");
+    audio_queue_post(Q_AUDIO_AA_WORK, 0);
+}
+
+static void playback_aa_on_work(void)
+{
+    static struct mp3entry aa_id3;
+    unsigned int gen = aa_job_gen;
+    int off;
+    bool current_done = false;
+
+    if (play_status == PLAY_STOPPED)
+        return;
+
+    if (aa_work_index >= AA_WINDOW_SIZE)
+        return;
+
+    off = aa_work_order[aa_work_index];
+    aa_work_index++;
+
+    if (playlist_check(off))
+    {
+        wipe_mp3entry(&aa_id3);
+        if (playback_aa_fill_id3(off, &aa_id3))
+            current_done = albumart_cache_work(off, &aa_id3);
+        else
+            current_done = albumart_cache_work(off, NULL);
+    }
+
+    if (current_done)
+    {
+        send_track_event(PLAYBACK_EVENT_CUR_TRACK_READY, 0,
+                         id3_get(PLAYING_ID3));
+        /* Return to queue_wait so the lower-priority WPS thread can
+         * redraw. Neighbors resume on SYS_TIMEOUT. */
+        return;
+    }
+
+    sleep(1);
+
+    if (gen != aa_job_gen || play_status == PLAY_STOPPED)
+        return;
+
+    if (aa_work_index < AA_WINDOW_SIZE)
+    {
+        LOGFQUEUE("audio > audio Q_AUDIO_AA_WORK");
+        audio_queue_post(Q_AUDIO_AA_WORK, 0);
+    }
+}
+#endif /* HAVE_ALBUMART */
 
 /* Set up the audio buffer for playback
  * filebuflen must be pre-initialized with the maximum size */
@@ -894,7 +965,7 @@ static void audio_reset_buffer_noalloc(
 {
     /*
      * Layout audio buffer as follows:
-     * [|SCRATCH|BUFFERING|PCM]
+     * [|SCRATCH|AA|BUFFERING|PCM]
      */
     logf("%s()", __func__);
 
@@ -924,7 +995,18 @@ static void audio_reset_buffer_noalloc(
     filebuflen -= allocsize;
 
 #ifdef HAVE_ALBUMART
-    clear_last_folder_album_art();
+    {
+        struct dim dims[MAX_MULTIPLE_AA];
+        playback_aa_claimed_dims(dims);
+        allocsize = albumart_cache_pool_size(dims, MAX_MULTIPLE_AA);
+        allocsize = ALIGN_UP(allocsize, sizeof(intptr_t));
+        if (allocsize > filebuflen)
+            goto bufpanic;
+        albumart_cache_reset(allocsize ? filebuf : NULL, allocsize,
+                             dims, MAX_MULTIPLE_AA);
+        filebuf += allocsize;
+        filebuflen -= allocsize;
+    }
 #endif
 
     buffering_reset(filebuf, filebuflen);
@@ -1914,111 +1996,6 @@ void set_albumart_mode(int setting)
     albumart_mode = setting;
 }
 
-static int load_album_art_from_path(char *path, struct bufopen_bitmap_data *user_data, bool is_current_track, int i)
-{
-    user_data->embedded_albumart = NULL;
-
-    bool same_path = strcmp(last_folder_aa_path, path) == 0;
-    if (same_path && last_folder_aa_hid[i] != 0)
-        return last_folder_aa_hid[i];
-
-    // To simplify caching logic a bit we keep track only for first AA path
-    // If other album arts use different path (like dimension specific arts) just skip caching for them
-    bool is_cacheable = i == 0 && (is_current_track || last_folder_aa_path[0] == 0);
-    if (!same_path && is_cacheable)
-    {
-        clear_last_folder_album_art();
-        strcpy(last_folder_aa_path, path);
-    }
-    int hid = bufopen(path, 0, TYPE_BITMAP, user_data);
-    if (hid != ERR_BUFFER_FULL && (same_path || is_cacheable))
-        last_folder_aa_hid[i] = hid;
-    return hid;
-}
-
-/* Load any album art for the file - returns false if the buffer is full */
-static int audio_load_albumart(struct track_info *infop,
-                                struct mp3entry *track_id3, bool is_current_track)
-{
-    FOREACH_ALBUMART(i)
-    {
-        struct bufopen_bitmap_data user_data;
-        int *aa_hid = &infop->aa_hid[i];
-        int hid = ERR_UNSUPPORTED_TYPE;
-        bool checked_image_file = false;
-
-        /* albumart_slots may change during a yield of bufopen,
-         * but that's no problem */
-        if (*aa_hid >= 0 || *aa_hid == ERR_UNSUPPORTED_TYPE ||
-            !albumart_slots[i].used)
-            continue;
-
-        memset(&user_data, 0, sizeof(user_data));
-        user_data.dim = &albumart_slots[i].dim;
-
-        char path[MAX_PATH];
-        if(global_settings.album_art == AA_PREFER_IMAGE_FILE)
-        {
-            if (find_albumart(track_id3, path, sizeof(path),
-                          &albumart_slots[i].dim))
-            {
-                hid = load_album_art_from_path(path, &user_data, is_current_track, i);
-            }
-            checked_image_file = true;
-        }
-
-        /* We can only decode jpeg for embedded AA */
-        if (global_settings.album_art != AA_OFF &&
-            hid < 0 && hid != ERR_BUFFER_FULL &&
-            track_id3->has_embedded_albumart && (track_id3->albumart.type & AA_CLEAR_FLAGS_MASK) == AA_TYPE_JPG)
-        {
-            if (is_current_track)
-                clear_last_folder_album_art();
-            user_data.embedded_albumart = &track_id3->albumart;
-            hid = bufopen(track_id3->path, 0, TYPE_BITMAP, &user_data);
-        }
-
-        if (global_settings.album_art != AA_OFF && !checked_image_file &&
-            hid < 0 && hid != ERR_BUFFER_FULL)
-        {
-            /* No embedded AA or it couldn't be loaded - try other sources */
-            if (find_albumart(track_id3, path, sizeof(path),
-                              &albumart_slots[i].dim))
-            {
-                hid = load_album_art_from_path(path, &user_data, is_current_track, i);
-            }
-        }
-
-        if (hid == ERR_BUFFER_FULL)
-        {
-            logf("buffer is full for now (%s)", __func__);
-            return ERR_BUFFER_FULL;
-        }
-        else if (hid == ERR_BITMAP_TOO_LARGE){
-            logf("image is too large to fit in buffer (%s)", __func__);
-            return ERR_BITMAP_TOO_LARGE;
-        }
-        else
-        {
-            /* If error other than a full buffer, then mark it "unsupported"
-               to avoid reloading attempt */
-            if (hid < 0)
-            {
-                logf("Album art loading failed");
-                hid = ERR_UNSUPPORTED_TYPE;
-            }
-            else
-            {
-                logf("Loaded album art:%dx%d", user_data.dim->width,
-                     user_data.dim->height);
-            }
-
-            *aa_hid = hid;
-        }
-    }
-
-    return true;
-}
 #endif /* HAVE_ALBUMART */
 
 #ifdef HAVE_CODEC_BUFFERING
@@ -2296,21 +2273,6 @@ static int audio_finish_load_track(struct track_info *infop)
         filling = STATE_FULL;
         goto audio_finish_load_track_exit;
     }
-
-#ifdef HAVE_ALBUMART
-    /* Try to load album art for the track */
-    int retval = audio_load_albumart(infop, track_id3, infop->self_hid == cur_info.self_hid);
-    if (retval == ERR_BITMAP_TOO_LARGE)
-    {
-        /* No space for album art on buffer because the file is larger than the buffer.
-        Ignore the file and keep buffering */
-    } else if (retval == ERR_BUFFER_FULL)
-    {
-        /* No space for album art on buffer, not an error */
-        filling = STATE_FULL;
-        goto audio_finish_load_track_exit;
-    }
-#endif
 
     /* All handles available to external routines are ready - audio and codec
        information is private */
@@ -2622,6 +2584,9 @@ static void audio_on_finish_load_track(int id3_hid)
                 audio_playlist_track_change();
             }
         }
+#ifdef HAVE_ALBUMART
+        playback_aa_kick();
+#endif
     }
     else
     {
@@ -2766,6 +2731,10 @@ static void audio_finalise_track_change(void)
     id3_mutex_unlock();
 
     audio_playlist_track_change();
+
+#ifdef HAVE_ALBUMART
+    playback_aa_kick();
+#endif
 
 #ifdef HAVE_PLAY_FREQ
     if (filling == STATE_STOPPED)
@@ -3170,7 +3139,7 @@ static void audio_stop_playback(void)
 
     wipe_track_metadata(true);
 #ifdef HAVE_ALBUMART
-    clear_last_folder_album_art();
+    albumart_cache_clear();
 #endif
     /* Go idle */
     filling = STATE_IDLE;
@@ -3212,9 +3181,18 @@ static void audio_on_skip(void)
 {
     id3_mutex_lock();
 
-    /* Eat the delta to keep it synced, even if not playing */
+    /* Eat the delta to keep it synced, even if not playing.
+     * Slide the AA window in the same lock as clearing skip_offset so
+     * the WPS never draws window[0] (old current) after previewing +1. */
     int toskip = skip_offset;
+#ifdef HAVE_ALBUMART
+    albumart_cache_lock();
+#endif
     skip_offset = 0;
+#ifdef HAVE_ALBUMART
+    albumart_cache_slide_locked(toskip);
+    albumart_cache_unlock();
+#endif
 
     logf("%s(): %d", __func__, toskip);
 
@@ -3636,6 +3614,13 @@ void audio_playback_handler(struct queue_event *ev)
             audio_on_fill_buffer();
             break;
 
+#ifdef HAVE_ALBUMART
+        case Q_AUDIO_AA_WORK:
+            LOGFQUEUE("playback < Q_AUDIO_AA_WORK");
+            playback_aa_on_work();
+            break;
+#endif
+
         case Q_AUDIO_FINISH_LOAD_TRACK:
             /* metadata is buffered */
             LOGFQUEUE("playback < Q_AUDIO_FINISH_LOAD_TRACK");
@@ -3670,6 +3655,13 @@ void audio_playback_handler(struct queue_event *ev)
 
         case SYS_TIMEOUT:
             LOGFQUEUE_SYS_TIMEOUT("playback < SYS_TIMEOUT");
+#ifdef HAVE_ALBUMART
+            if (aa_work_index < AA_WINDOW_SIZE &&
+                play_status != PLAY_STOPPED)
+            {
+                playback_aa_on_work();
+            }
+#endif
             break;
 
         default:
@@ -4092,25 +4084,25 @@ void audio_flush_and_reload_tracks(void)
 /** --- Miscellaneous public interfaces --- **/
 
 #ifdef HAVE_ALBUMART
-/* Return which album art handle is current for the user in the given slot */
-int playback_current_aa_hid(int slot)
+/* Return decoded album art for the user-visible track in the given slot */
+struct bitmap *playback_current_aa_bitmap(int slot)
 {
-    if ((unsigned)slot < MAX_MULTIPLE_AA)
-    {
-        struct track_info user_cur;
-        bool have_info = track_list_user_current(skip_offset, &user_cur);
+    struct bitmap *bmp = NULL;
+    int offset;
 
-        if (!have_info && abs(skip_offset) <= 1)
-        {
-            /* Give the actual position a go */
-            have_info = track_list_user_current(0, &user_cur);
-        }
+    if ((unsigned)slot >= MAX_MULTIPLE_AA)
+        return NULL;
 
-        if (have_info)
-            return user_cur.aa_hid[slot];
-    }
+    albumart_cache_lock();
+    offset = skip_offset;
 
-    return ERR_HANDLE_NOT_FOUND;
+    if (skip_pending == TRACK_SKIP_AUTO ||
+        skip_pending == TRACK_SKIP_AUTO_NEW_PLAYLIST)
+        offset--;
+
+    bmp = albumart_cache_get_locked(offset, slot);
+    albumart_cache_unlock();
+    return bmp;
 }
 
 /* Find an album art slot that doesn't match the dimensions of another that
@@ -4162,6 +4154,21 @@ void playback_update_aa_dims(void)
 {
     LOGFQUEUE("audio >| audio Q_AUDIO_REMAKE_AUDIO_BUFFER");
     audio_queue_send(Q_AUDIO_REMAKE_AUDIO_BUFFER, 0);
+}
+
+void playback_aa_get_debugdata(struct albumart_cache_debug *dbg)
+{
+    if (!dbg)
+        return;
+
+    albumart_cache_get_debugdata(dbg);
+
+    dbg->work_index = aa_work_index;
+    if (aa_work_index < AA_WINDOW_SIZE)
+        dbg->work_offset = aa_work_order[aa_work_index];
+    else
+        dbg->work_offset = 0;
+    dbg->skip_offset = skip_offset;
 }
 #endif /* HAVE_ALBUMART */
 

--- a/apps/playback.h
+++ b/apps/playback.h
@@ -34,13 +34,15 @@
 #endif
 
 #ifdef HAVE_ALBUMART
-
 #include "bmp.h"
 #include "metadata.h"
+#include "albumart_cache.h"
 /*
- * Returns the handle id of the buffered albumart for the given slot id
- **/
-int playback_current_aa_hid(int slot);
+ * Returns the decoded album art bitmap for the given slot, or NULL.
+ * Window is ±2 around playlist current; skip_offset is applied for
+ * fast skip preview.
+ */
+struct bitmap *playback_current_aa_bitmap(int slot);
 
 /*
  * Hands out an albumart slot for buffering albumart using the size
@@ -64,6 +66,9 @@ void playback_release_aa_slot(int slot);
  *
  * Save to call from other threads */
 void playback_update_aa_dims(void);
+
+/* Snapshot AA window + background job for the buffering debug screen */
+void playback_aa_get_debugdata(struct albumart_cache_debug *dbg);
 
 struct bufopen_bitmap_data {
     struct dim *dim;

--- a/apps/recorder/albumart.c
+++ b/apps/recorder/albumart.c
@@ -30,6 +30,14 @@
 #include "pathfuncs.h"
 #include "settings.h"
 #include "wps.h"
+#ifndef PLUGIN
+#include "file.h"
+#include "bmp.h"
+#ifdef HAVE_JPEG
+#include "jpeg_load.h"
+#endif
+#include "resize.h"
+#endif
 
 /* Define LOGF_ENABLE to enable logf output in this file */
 /*#define LOGF_ENABLE*/
@@ -275,6 +283,61 @@ bool find_albumart(const struct mp3entry *id3, char *buf, int buflen,
     /* Then we look for generic bitmaps */
     *size_string = 0;
     return search_albumart_files(id3, size_string, buf, buflen);
+}
+
+size_t albumart_decoded_size(const struct dim *dim)
+{
+    return sizeof(struct bitmap) +
+           BM_SIZE(dim->width, dim->height, FORMAT_NATIVE, false);
+}
+
+size_t albumart_decode_overhead(int width)
+{
+    size_t size = 0;
+#ifdef HAVE_JPEG
+    size += JPEG_DECODE_OVERHEAD;
+#endif
+#ifdef HAVE_LCD_COLOR
+    size += sizeof(struct uint32_argb) * 3 * width;
+#else
+    size += sizeof(uint32_t) * 3 * width;
+#endif
+    return size;
+}
+
+int albumart_decode_fd(int fd, const char *path, const struct dim *dim,
+                       struct mp3_albumart *embedded,
+                       void *buf, size_t max_size)
+{
+    int rc;
+    struct bitmap *bmp = buf;
+
+    if (!buf || !dim || max_size < sizeof(struct bitmap))
+        return 0;
+
+    bmp->width = dim->width;
+    bmp->height = dim->height;
+    bmp->data = (unsigned char *)buf + sizeof(struct bitmap);
+#if (LCD_DEPTH > 1) || defined(HAVE_REMOTE_LCD) && (LCD_REMOTE_DEPTH > 1)
+    bmp->maskdata = NULL;
+#endif
+    const int format = FORMAT_NATIVE | FORMAT_DITHER |
+                       FORMAT_RESIZE | FORMAT_KEEP_ASPECT;
+#ifdef HAVE_JPEG
+    if (embedded != NULL)
+    {
+        lseek(fd, embedded->pos, SEEK_SET);
+        rc = clip_jpeg_fd(fd, embedded->type, embedded->size, bmp,
+                          (int)max_size, format, NULL);
+    }
+    else if (path && strlen(path) >= 4 &&
+             strcmp(path + strlen(path) - 4, ".bmp"))
+        rc = read_jpeg_fd(fd, bmp, (int)max_size, format, NULL);
+    else
+#endif
+        rc = read_bmp_fd(fd, bmp, (int)max_size, format, NULL);
+
+    return rc + (rc > 0 ? (int)sizeof(struct bitmap) : 0);
 }
 
 #endif /* PLUGIN */

--- a/apps/recorder/albumart.h
+++ b/apps/recorder/albumart.h
@@ -25,6 +25,7 @@
 #if defined(HAVE_ALBUMART) || defined(PLUGIN)
 
 #include <stdbool.h>
+#include <stddef.h>
 #include "metadata.h"
 #include "skin_engine/skin_engine.h"
 
@@ -39,6 +40,18 @@ bool search_albumart_files(const struct mp3entry *id3, const char *size_string,
                            char *buf, int buflen);
 
 void get_albumart_size(struct bitmap *bmp);
+
+#ifndef PLUGIN
+/* Decoded native bitmap bytes for a target dim, including struct bitmap */
+size_t albumart_decoded_size(const struct dim *dim);
+/* Extra workspace JPEG/BMP loaders need on top of the pixel buffer */
+size_t albumart_decode_overhead(int width);
+/* Decode file or embedded JPEG into buf. Returns total bytes used
+ * (struct bitmap + pixels) or <= 0 on failure. */
+int albumart_decode_fd(int fd, const char *path, const struct dim *dim,
+                       struct mp3_albumart *embedded,
+                       void *buf, size_t max_size);
+#endif
 
 #endif /* HAVE_ALBUMART */
 

--- a/tools/checkwps/checkwps.c
+++ b/tools/checkwps/checkwps.c
@@ -115,6 +115,12 @@ void playback_release_aa_slot(int slot)
 {
     return;
 }
+
+struct bitmap *playback_current_aa_bitmap(int slot)
+{
+    (void)slot;
+    return NULL;
+}
 #endif
 
 int resize_on_load(struct bitmap *bm, bool dither,


### PR DESCRIPTION
Integrated AA caching : 

AA is a dedicated +-2 sliding window pool (Total=5) allocated from the audio buffer. Buffer size is reduced by ~1MB. 
Decoupled play/skip wait on JPEG decode. Audio starts when ready, after which AA loads on the background. WPS is refreshed when current AA is ready. Neighbouring AA slots are filled in the background. 

View Buffer Thread Debug menu option now contains diagnostic information on AA pool .